### PR TITLE
Fix #3: drop broken CORS proxy, use MediaWiki API directly

### DIFF
--- a/main.js
+++ b/main.js
@@ -537,29 +537,37 @@ function getAvg(nums) {
 }
 
 /**
+ * Fetch a progress page and parse its first <table> into JSON.
  *
- * @param {string} url
+ * For wiki.openstreetmap.org we hit the MediaWiki action API with origin=*
+ * for CORS. For other hosts we fetch the page directly — works as long as
+ * the host sends Access-Control-Allow-Origin (GitHub Pages does).
+ *
+ * @param {string} hostname
  * @param {string} path
  * @returns
  */
-async function convertWikiToJson(url, path) {
-  const resp = await fetch(
-    `https://production.osmno-cors-proxy.mathiash98.workers.dev/${path}?url=${url}`
-  );
-
-  if (resp.ok) {
-    // parse html table and get percentage for each kommune
-    const progressDocumentText = await resp.text();
-    const progressHtml = new DOMParser().parseFromString(
-      progressDocumentText,
-      "text/html"
-    );
-    const progressTable = progressHtml.querySelector("table");
-    const tableAsJson = parseHTMLTableElem(progressTable);
-    return tableAsJson;
+async function convertWikiToJson(hostname, path) {
+  let html;
+  if (hostname === "wiki.openstreetmap.org") {
+    const page = path.replace(/^wiki\//, "");
+    const apiUrl = `https://${hostname}/w/api.php?action=parse&page=${encodeURIComponent(
+      page
+    )}&prop=text&format=json&origin=*`;
+    const resp = await fetch(apiUrl);
+    if (!resp.ok) throw new Error(resp.statusText);
+    const json = await resp.json();
+    if (json.error) throw new Error(json.error.info);
+    html = json.parse.text["*"];
   } else {
-    throw new Error(resp.statusText);
+    const resp = await fetch(`https://${hostname}/${path}`);
+    if (!resp.ok) throw new Error(resp.statusText);
+    html = await resp.text();
   }
+
+  const progressHtml = new DOMParser().parseFromString(html, "text/html");
+  const progressTable = progressHtml.querySelector("table");
+  return parseHTMLTableElem(progressTable);
 }
 
 /**


### PR DESCRIPTION
Closes #3.

## Diagnose

CORS-proxyen `production.osmno-cors-proxy.mathiash98.workers.dev` (Cloudflare Worker) returnerer gzip-komprimert body men sender ikke med `Content-Encoding: gzip`-header. Browseren ser `Content-Type: text/html` og prøver å parse rå gzip-bytes som tekst → `ERR_CONTENT_DECODING_FAILED` på alle datasett.

Bekreftet ved å lagre svaret rått:
```
$ curl -s "https://production.osmno-cors-proxy.mathiash98.workers.dev/wiki/...?url=wiki.openstreetmap.org" -o r.bin
$ file r.bin
r.bin: gzip compressed data, original size modulo 2^32 46531
```
Body er gzip, men ingen `content-encoding`-header i responsen.

## Løsning

Begge datakildene serverer allerede CORS-headere selv — proxyen er overflødig:

| Kilde | CORS-test |
|---|---|
| `wiki.openstreetmap.org/w/api.php?...&origin=*` | `access-control-allow-origin: *` |
| `obtitus.github.io/...` (GitHub Pages) | `access-control-allow-origin: *` |

For wiki bruker vi MediaWiki action API (`action=parse&prop=text&format=json&origin=*`) og henter rendret HTML fra `parse.text["*"]`. For andre hostnavn (per nå kun `obtitus.github.io`) henter vi siden direkte.

Fordeler:
- Fjerner et single point of failure hostet på en personlig Cloudflare-konto.
- MediaWiki-API-et er stabilt og dokumentert.
- Kortere requestkjede.

## Test

Kjørt lokalt mot `http://localhost:8765/?project=ssr` (og verifisert med `curl` for alle 6 datasett: byggimport, NVDB-mangler, highway-tag, SSR, N50, barnehagefakta). Alle kall returnerer 200 og kommunene blir fargelagt korrekt på kartet.

## Test plan

- [ ] Verifiser at alle prosjekter (SSR, NVDB missing, Highway tags, N50, Barnehagefakta, Building import) laster og fargelegger kommuner på `osmno.github.io/progress-visualizer/`.
- [ ] Verifiser ingen `Failed to fetch` / `ERR_CONTENT_DECODING_FAILED` i console.